### PR TITLE
multiplatform CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,11 +4,11 @@ on: [push, pull_request]
 
 jobs:
   build:
-    strategy:
-      max-parallel: 4
-      matrix:
-        python-version: ['3.8', '3.9', '3.10']
-        os: [ubuntu-latest, macos-latest, windows-latest]
+    # strategy:
+    #   max-parallel: 4
+    #   matrix:
+    #     python-version: ['3.8', '3.9', '3.10']
+    #     os: [ubuntu-latest, macos-latest, windows-latest]
 
     # runs-on: ${{ matrix.os }}
     runs-on: windows-latest
@@ -35,7 +35,7 @@ jobs:
       run: |
         python setup.py sdist bdist_wheel
         ls -l ${{ github.workspace }}
-
+        ls -l ${{ github.workspace }}/dist/*.*
 
   upload:
     needs: build
@@ -45,7 +45,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: diffpy2 - Python ${{ matrix.python-version }}
-        path: ${{ github.workspace }}/../dist/*
+        path: ${{ github.workspace }}/dist/*.*
 
     # - name: Upload zipped offline app installer to GitHub releases
     #   uses: ncipollo/release-action@v1

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,8 +45,8 @@ jobs:
 
     - name: show content
       run: |
-        ls -l ${{ github.workspace }}
-        ls -l ${{ github.workspace }}/dist
+        ls -l ${{ github.workspace }}/../
+        ls -l ${{ github.workspace }}/../dist
 
     - uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,7 +4,14 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: windows-2019
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: ['3.8', '3.9', '3.10']
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    # runs-on: ${{ matrix.os }}
+    runs-on: windows-latest
     steps:
     - name: Check-out repository
       uses: actions/checkout@v2
@@ -13,7 +20,7 @@ jobs:
       uses: s-weigand/setup-conda@v1
       with:
         update-conda: true
-        python-version: 3.8
+        python-version: ${{ matrix.python-version }}
 
     - name: Install dependencies
       run: |
@@ -29,20 +36,25 @@ jobs:
 
   upload:
     needs: build
-    runs-on: windows-2019
+    runs-on: ubuntu-latest
     steps:
 
-    - name: Upload zipped offline app installer to GitHub releases
-      uses: ncipollo/release-action@v1
+    - uses: actions/upload-artifact@v2
       with:
-        draft: true
-        prerelease: true
-        allowUpdates: true
-        replacesArtifacts: true
-        token: ${{ secrets.GITHUB_TOKEN }}
-        artifacts: ./**/*.whl
-        tag: 1.4.1
-        body: This is an alpha build of diffpy2
+        name: diffpy2 - Python ${{ matrix.python-version }}
+        path: ${{ github.workspace }}/dist/*
+
+    # - name: Upload zipped offline app installer to GitHub releases
+    #   uses: ncipollo/release-action@v1
+    #   with:
+    #     draft: true
+    #     prerelease: true
+    #     allowUpdates: true
+    #     replacesArtifacts: true
+    #     token: ${{ secrets.GITHUB_TOKEN }}
+    #     artifacts: dist/*.whl
+    #     tag: 1.4.1
+    #     body: This is an alpha build of diffpy2
 
 
   # upload:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,7 +35,8 @@ jobs:
       run: |
         python setup.py sdist bdist_wheel
         ls -l ${{ github.workspace }}
-        ls -l ${{ github.workspace }}/dist/*.*
+        ls -l ${{ github.workspace }}/dist
+        ls -l ${{ github.workspace }}/build
 
   upload:
     needs: build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,14 +4,13 @@ on: [push, pull_request]
 
 jobs:
   build:
-    # strategy:
-    #   max-parallel: 4
-    #   matrix:
-    #     python-version: ['3.8', '3.9', '3.10']
-    #     os: [ubuntu-latest, macos-latest, windows-latest]
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: ['3.8', '3.9', '3.10']
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
-    # runs-on: ${{ matrix.os }}
-    runs-on: windows-latest
+    runs-on: ${{ matrix.os }}
     steps:
     - name: Check-out repository
       uses: actions/checkout@v2
@@ -20,8 +19,7 @@ jobs:
       uses: s-weigand/setup-conda@v1
       with:
         update-conda: true
-        # python-version: ${{ matrix.python-version }}
-        python-version: '3.8'
+        python-version: ${{ matrix.python-version }}
 
     - name: Install dependencies
       run: |
@@ -31,70 +29,33 @@ jobs:
         conda install -c conda-forge pip
         conda install -c conda-forge gsl
 
-    - name: Build package
+    - name: Build wheels
       run: |
         python setup.py sdist bdist_wheel
-        ls -l ${{ github.workspace }}
-        ls -l ${{ github.workspace }}/dist
-        ls -l ${{ github.workspace }}/build
 
-  upload:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-
-    - name: show content
+    - name: Run tests
       run: |
-        ls -l ${{ github.workspace }}/../
-        ls -l ${{ github.workspace }}/../dist
+        conda install -c conda-forge numpy
+        python setup.py install
+        python conda-recipe/run_test.py
 
-    - uses: actions/upload-artifact@v2
+    - name: Upload Artifacts GitHub releases
+      uses: ncipollo/release-action@v1
       with:
-        name: diffpy2 - Python ${{ matrix.python-version }}
-        path: ${{ github.workspace }}/dist/*.whl
+        draft: false
+        prerelease: true
+        allowUpdates: true
+        replacesArtifacts: true
+        token: ${{ secrets.GITHUB_TOKEN }}
+        artifacts: ${{ github.workspace }}/dist/*.whl
+        tag: 1.4.0
+        body: This is an alpha build of the pdffit2 library (1.4.0)
 
-    # - name: Upload zipped offline app installer to GitHub releases
-    #   uses: ncipollo/release-action@v1
+    # This step will upload tagged commits to pypi.
+    # The pypi token must be added to GH secrets
+    # 
+    # - name: Publish package
+    #   if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    #   uses: pypa/gh-action-pypi-publish@release/v1
     #   with:
-    #     draft: true
-    #     prerelease: true
-    #     allowUpdates: true
-    #     replacesArtifacts: true
-    #     token: ${{ secrets.GITHUB_TOKEN }}
-    #     artifacts: dist/*.whl
-    #     tag: 1.4.1
-    #     body: This is an alpha build of diffpy2
-
-
-  # upload:
-  #   steps:
-  #   - name: Checkout target repo
-  #     uses: actions/checkout@v3
-  #     env:
-  #       REPO: easyScience/pypi
-  #       REPO_PATH: pypi
-  #     with:
-  #       fetch-depth: 0
-  #       token: ${{ secrets.ES_TOKEN }}
-  #       repository: ${{ env.REPO }}
-  #       path: ${{ env.REPO_PATH }}
-
-  #   - name: Copy index to new repo
-  #     env:
-  #       SOURCE: index.html
-  #       TARGET: pypi/easysciencecore/
-  #     run: cp ${{ env.SOURCE }} ${{ env.TARGET }}
-  #   - name: Push
-  #     env:
-  #       REPO_PATH: pypi
-  #       GIT_USERNAME: action
-  #       GIT_EMAIL: action@github.com
-  #     run: |
-  #       cd ${{ env.REPO_PATH }}
-  #       git config --local user.name "${{ env.GIT_USERNAME }}"
-  #       git config --local user.email "${{ env.GIT_EMAIL }}"
-  #       git add .
-  #       if [[ `git status --porcelain` ]]; then
-  #         git commit -m "Github Actions Automatically Built in `date +"%Y-%m-%d %H:%M"`"
-  #         git push
-  #       fi
+    #     password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,10 +43,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+    - name: show content
+      run: |
+        ls -l ${{ github.workspace }}
+        ls -l ${{ github.workspace }}/dist
+
     - uses: actions/upload-artifact@v2
       with:
         name: diffpy2 - Python ${{ matrix.python-version }}
-        path: ${{ github.workspace }}/dist/*.*
+        path: ${{ github.workspace }}/dist/*.whl
 
     # - name: Upload zipped offline app installer to GitHub releases
     #   uses: ncipollo/release-action@v1

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,6 +31,7 @@ jobs:
     needs: build
     runs-on: windows-2019
     steps:
+
     - name: Upload zipped offline app installer to GitHub releases
       uses: ncipollo/release-action@v1
       with:
@@ -40,8 +41,8 @@ jobs:
         replacesArtifacts: true
         token: ${{ secrets.GITHUB_TOKEN }}
         artifacts: ./**/*.whl
-        tag: ${{ steps.name.outputs.tag }}
-        body: This is an alpha build of diffpy2 (${{ steps.name.outputs.tag }})
+        tag: 1.4.1
+        body: This is an alpha build of diffpy2
 
 
   # upload:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,77 @@
+name: build and upload
+
+on: [push, pull_request]
+
+jobs:
+  build:
+  timeout-minutes: 30
+    runs-on: windows-2019
+    steps:
+    - name: Check-out repository
+      uses: actions/checkout@v2
+
+    - name: set up conda
+      uses: s-weigand/setup-conda@v1
+      with:
+        update-conda: true
+        python-version: 3.8
+
+    - name: Install dependencies
+      run: |
+        conda install -c conda-forge twine
+        conda install -c conda-forge wheel
+        conda install -c conda-forge setuptools
+        conda install -c conda-forge pip
+        conda install -c conda-forge gsl
+
+    - name: Build package
+      run: |
+        python setup.py sdist bdist_wheel
+
+  upload:
+    - name: Upload zipped offline app installer to GitHub releases (non-master branch)
+      if: github.event_name == 'push' && env.BRANCH_NAME != 'master'
+      uses: ncipollo/release-action@v1
+      with:
+        draft: true
+        prerelease: true
+        allowUpdates: true
+        replacesArtifacts: true
+        token: ${{ secrets.GITHUB_TOKEN }}
+        artifacts: ./**/*.whl
+        tag: ${{ steps.name.outputs.tag }}
+        body: This is an alpha build of diffpy2 (${{ steps.name.outputs.tag }})
+
+
+  # upload:
+  #   steps:
+  #   - name: Checkout target repo
+  #     uses: actions/checkout@v3
+  #     env:
+  #       REPO: easyScience/pypi
+  #       REPO_PATH: pypi
+  #     with:
+  #       fetch-depth: 0
+  #       token: ${{ secrets.ES_TOKEN }}
+  #       repository: ${{ env.REPO }}
+  #       path: ${{ env.REPO_PATH }}
+
+  #   - name: Copy index to new repo
+  #     env:
+  #       SOURCE: index.html
+  #       TARGET: pypi/easysciencecore/
+  #     run: cp ${{ env.SOURCE }} ${{ env.TARGET }}
+  #   - name: Push
+  #     env:
+  #       REPO_PATH: pypi
+  #       GIT_USERNAME: action
+  #       GIT_EMAIL: action@github.com
+  #     run: |
+  #       cd ${{ env.REPO_PATH }}
+  #       git config --local user.name "${{ env.GIT_USERNAME }}"
+  #       git config --local user.email "${{ env.GIT_EMAIL }}"
+  #       git add .
+  #       if [[ `git status --porcelain` ]]; then
+  #         git commit -m "Github Actions Automatically Built in `date +"%Y-%m-%d %H:%M"`"
+  #         git push
+  #       fi

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,8 @@ jobs:
       uses: s-weigand/setup-conda@v1
       with:
         update-conda: true
-        python-version: ${{ matrix.python-version }}
+        # python-version: ${{ matrix.python-version }}
+        python-version: '3.8'
 
     - name: Install dependencies
       run: |
@@ -33,6 +34,8 @@ jobs:
     - name: Build package
       run: |
         python setup.py sdist bdist_wheel
+        ls -l ${{ github.workspace }}
+
 
   upload:
     needs: build
@@ -42,7 +45,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: diffpy2 - Python ${{ matrix.python-version }}
-        path: ${{ github.workspace }}/dist/*
+        path: ${{ github.workspace }}/../dist/*
 
     # - name: Upload zipped offline app installer to GitHub releases
     #   uses: ncipollo/release-action@v1

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,7 +4,6 @@ on: [push, pull_request]
 
 jobs:
   build:
-  timeout-minutes: 30
     runs-on: windows-2019
     steps:
     - name: Check-out repository
@@ -29,8 +28,10 @@ jobs:
         python setup.py sdist bdist_wheel
 
   upload:
-    - name: Upload zipped offline app installer to GitHub releases (non-master branch)
-      if: github.event_name == 'push' && env.BRANCH_NAME != 'master'
+    needs: build
+    runs-on: windows-2019
+    steps:
+    - name: Upload zipped offline app installer to GitHub releases
       uses: ncipollo/release-action@v1
       with:
         draft: true

--- a/pdffit2module/PyFileStreambuf.h
+++ b/pdffit2module/PyFileStreambuf.h
@@ -25,6 +25,7 @@
 
 #ifndef PYFILESTREAMBUF_H_INCLUDED
 #define PYFILESTREAMBUF_H_INCLUDED
+#define PY_SSIZE_T_CLEAN
 
 #include <Python.h>
 #include <streambuf>

--- a/pdffit2module/bindings.cc
+++ b/pdffit2module/bindings.cc
@@ -17,7 +17,7 @@
 * Comments:
 *
 ***********************************************************************/
-
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 #include "bindings.h"

--- a/pdffit2module/misc.cc
+++ b/pdffit2module/misc.cc
@@ -17,7 +17,7 @@
 * Comments:
 *
 ***********************************************************************/
-
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include <vector>
 #include <string>

--- a/pdffit2module/pdffit2module.cc
+++ b/pdffit2module/pdffit2module.cc
@@ -17,7 +17,7 @@
 * Comments:
 *
 ***********************************************************************/
-
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include <ostream>
 

--- a/pdffit2module/pyexceptions.cc
+++ b/pdffit2module/pyexceptions.cc
@@ -17,7 +17,7 @@
 * Comments:
 *
 ***********************************************************************/
-
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 PyObject *pypdffit2_runtimeError = 0;

--- a/setup.py
+++ b/setup.py
@@ -31,15 +31,16 @@ gitarchivecfgfile = os.path.join(MYDIR, '.gitarchive.cfg')
 
 
 def gitinfo():
-    from subprocess import Popen, PIPE
+    from subprocess import Popen, PIPE, check_output
     kw = dict(stdout=PIPE, cwd=MYDIR, universal_newlines=True)
     proc = Popen(['git', 'describe', '--tags', '--match=v[[:digit:]]*'], **kw)
     desc = proc.stdout.read()
     proc = Popen(['git', 'log', '-1', '--format=%H %ct %ci'], **kw)
     glog = proc.stdout.read()
     rv = {}
-    rv['version'] = '.post'.join(desc.strip().split('-')[:2]).lstrip('v')
     rv['commit'], rv['timestamp'], rv['date'] = glog.strip().split(None, 2)
+    version = check_output(['git', 'tag']).decode('ascii').strip()
+    rv['version'] = version
     return rv
 
 
@@ -163,25 +164,6 @@ elif compiler_type == "msvc":
     library_dirs += gcfg['library_dirs']
 # add optimization flags for other compilers if needed
 
-# print("INCLUDE DIR = {!r}".format(include_dirs))
-# print("LIBRARY DIR = {!r}".format(library_dirs))
-# import glob
-
-# pattern = 'gsl*.*'
-
-# library_dir = library_dirs[0]
-# matching_files = glob.glob(library_dir + '/' + pattern)
-# if len(matching_files) != 0:
-#     print("GSL LIBRARY FOUND in {!r}".format(matching_files[0]))
-
-# print("----- CONDA -----")
-# library_dir = "C:\\Miniconda"
-# matching_files = glob.glob(library_dir + '\\' + pattern)
-# if len(matching_files) != 0:
-#     for f in matching_files:
-#         print(f)
-# # print("GSL LIBRARY FOUND in {!r}".format(matching_files[0]))
-# print("----- CONDA END -----")
 
 # define extension here
 pdffit2module = Extension('diffpy.pdffit2.pdffit2', [

--- a/setup.py
+++ b/setup.py
@@ -153,7 +153,14 @@ import glob
 
 pattern = 'gsl.*'
 
-matching_files = glob.glob(library_dirs + '\\' + pattern)
+library_dir = library_dirs[0]
+matching_files = glob.glob(library_dir + '/' + pattern)
+if len(matching_files) != 0:
+    print("GSL LIBRARY FOUND in {!r}".format(matching_files[0]))
+
+print("----- CONDA -----")
+library_dir = "C:\\Miniconda\\envs\\__setup_conda"
+matching_files = glob.glob(library_dir + '\\' + pattern)
 if len(matching_files) != 0:
     print("GSL LIBRARY FOUND in {!r}".format(matching_files[0]))
 

--- a/setup.py
+++ b/setup.py
@@ -151,7 +151,7 @@ print("INCLUDE DIR = {!r}".format(include_dirs))
 print("LIBRARY DIR = {!r}".format(library_dirs))
 import glob
 
-pattern = 'gsl.*'
+pattern = 'gsl*.*'
 
 library_dir = library_dirs[0]
 matching_files = glob.glob(library_dir + '/' + pattern)
@@ -159,10 +159,13 @@ if len(matching_files) != 0:
     print("GSL LIBRARY FOUND in {!r}".format(matching_files[0]))
 
 print("----- CONDA -----")
-library_dir = "C:\\Miniconda\\envs\\__setup_conda"
+library_dir = "C:\\Miniconda"
 matching_files = glob.glob(library_dir + '\\' + pattern)
 if len(matching_files) != 0:
-    print("GSL LIBRARY FOUND in {!r}".format(matching_files[0]))
+    for f in matching_files:
+        print(f)
+# print("GSL LIBRARY FOUND in {!r}".format(matching_files[0]))
+print("----- CONDA END -----")
 
 # define extension here
 pdffit2module = Extension('diffpy.pdffit2.pdffit2', [

--- a/setup.py
+++ b/setup.py
@@ -147,6 +147,15 @@ elif compiler_type == "msvc":
     library_dirs += gcfg['library_dirs']
 # add optimization flags for other compilers if needed
 
+print("INCLUDE DIR = {!r}".format(include_dirs))
+print("LIBRARY DIR = {!r}".format(library_dirs))
+import glob
+
+pattern = 'gsl.*'
+
+matching_files = glob.glob(library_dirs + '\\' + pattern)
+if len(matching_files) != 0:
+    print("GSL LIBRARY FOUND in {!r}".format(matching_files[0]))
 
 # define extension here
 pdffit2module = Extension('diffpy.pdffit2.pdffit2', [

--- a/setup.py
+++ b/setup.py
@@ -123,11 +123,27 @@ def get_gsl_config():
     rv['library_dirs'] += [lib]
     return rv
 
+def get_gsl_config_win():
+    '''Return dictionary with paths to GSL library, windwows version.
+       This version is installed with conda.
+    '''
+    conda_prefix = os.environ['CONDA_PREFIX']
+    inc = os.path.join(conda_prefix, 'Library', 'include')
+    lib = os.path.join(conda_prefix, 'Library', 'lib')
+    rv = {'include_dirs': [], 'library_dirs': []}
+    rv['include_dirs'] += [inc]
+    rv['library_dirs'] += [lib]
+    return rv
+
 # ----------------------------------------------------------------------------
 
 # compile and link options
 define_macros = []
-gcfg = get_gsl_config()
+os_name = os.name
+if os_name == 'nt':
+    gcfg = get_gsl_config_win()
+else:
+    gcfg = get_gsl_config()
 include_dirs = [MYDIR] + gcfg['include_dirs']
 library_dirs = []
 libraries = []
@@ -147,25 +163,25 @@ elif compiler_type == "msvc":
     library_dirs += gcfg['library_dirs']
 # add optimization flags for other compilers if needed
 
-print("INCLUDE DIR = {!r}".format(include_dirs))
-print("LIBRARY DIR = {!r}".format(library_dirs))
-import glob
+# print("INCLUDE DIR = {!r}".format(include_dirs))
+# print("LIBRARY DIR = {!r}".format(library_dirs))
+# import glob
 
-pattern = 'gsl*.*'
+# pattern = 'gsl*.*'
 
-library_dir = library_dirs[0]
-matching_files = glob.glob(library_dir + '/' + pattern)
-if len(matching_files) != 0:
-    print("GSL LIBRARY FOUND in {!r}".format(matching_files[0]))
+# library_dir = library_dirs[0]
+# matching_files = glob.glob(library_dir + '/' + pattern)
+# if len(matching_files) != 0:
+#     print("GSL LIBRARY FOUND in {!r}".format(matching_files[0]))
 
-print("----- CONDA -----")
-library_dir = "C:\\Miniconda"
-matching_files = glob.glob(library_dir + '\\' + pattern)
-if len(matching_files) != 0:
-    for f in matching_files:
-        print(f)
-# print("GSL LIBRARY FOUND in {!r}".format(matching_files[0]))
-print("----- CONDA END -----")
+# print("----- CONDA -----")
+# library_dir = "C:\\Miniconda"
+# matching_files = glob.glob(library_dir + '\\' + pattern)
+# if len(matching_files) != 0:
+#     for f in matching_files:
+#         print(f)
+# # print("GSL LIBRARY FOUND in {!r}".format(matching_files[0]))
+# print("----- CONDA END -----")
 
 # define extension here
 pdffit2module = Extension('diffpy.pdffit2.pdffit2', [


### PR DESCRIPTION
This addressed issue #6 
This setup is currently being used to build and distribute pdffit2 from the EasyScience repository:
https://github.com/easyScience/pdffit2

Our local pypi repo is available here:
https://easyscience.github.io/pypi/diffpy-pdffit2/

We use pdffit2 as a PDF calculator for the EasyDiffraction suite for analysis of neutron diffraction experiments at ESS.

Once the builds are working here and the pypi upload set up, we can switch to using the official pypi repo, which would be advantageous.

The workflow runs tests on each push, since they are pretty quick.

The last part of the yaml file has been commented out and needs some care in order to enable pypi uploads (specifying pypi access token)

Changes in .cpp/.h files are to fix python 3.10 compilation issues on Windows. They should be benign.
