### PR TITLE
Workflow fix

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,12 +22,14 @@ jobs:
       uses: actions/checkout@v2
 
     - name: set up conda
-      uses: s-weigand/setup-conda@v1
+      uses: conda-incubator/setup-miniconda@v2
       with:
-        update-conda: true
+        auto-update-conda: true
         python-version: ${{ matrix.python-version }}
+        channels: conda-forge
 
     - name: Install dependencies
+      shell: bash -l {0}
       run: |
         conda install -c conda-forge twine
         conda install -c conda-forge wheel
@@ -36,10 +38,12 @@ jobs:
         conda install -c conda-forge gsl
 
     - name: Build wheels
+      shell: bash -l {0}
       run: |
         python setup.py sdist bdist_wheel
 
     - name: Run tests
+      shell: bash -l {0}
       run: |
         conda install -c conda-forge numpy
         python setup.py install

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,10 @@ lib64
 tags
 errors.err
 
+# IDE configs
+.idea
+.vscode
+
 # Installer logs
 pip-log.txt
 MANIFEST

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml


### PR DESCRIPTION
Should close #27, though this can't locally be tested exactly the same as git.
The main change is to use conda-incubator instead of s-weigand to build conda.
