### PR TITLE
Cookiecutting - pass tests

### DIFF
--- a/src/diffpy/__init__.py
+++ b/src/diffpy/__init__.py
@@ -1,23 +1,28 @@
 #!/usr/bin/env python
 ##############################################################################
 #
-# (c) 2024 The Trustees of Columbia University in the City of New York.
-# All rights reserved.
+# diffpy            by DANSE Diffraction group
+#                   Simon J. L. Billinge
+#                   (c) 2008 trustees of the Michigan State University.
+#                   All rights reserved.
 #
-# File coded by: Billinge Group members and community contributors.
+# File coded by:    Pavol Juhas
 #
-# See GitHub contributions for a more detailed list of contributors.
-# https://github.com/diffpy/diffpy.pdffit2/graphs/contributors
-#
-# See LICENSE.rst for license information.
+# See AUTHORS.txt for a list of people who contributed.
+# See LICENSE.txt for license information.
 #
 ##############################################################################
 
-"""Blank namespace package for module diffpy."""
+
+"""diffpy - tools for structure analysis by diffraction.
+
+Blank namespace package.
+"""
 
 
 from pkgutil import extend_path
 
 __path__ = extend_path(__path__, __name__)
+
 
 # End of file

--- a/src/diffpy/pdffit2/__init__.py
+++ b/src/diffpy/pdffit2/__init__.py
@@ -21,10 +21,10 @@ Routines:
 """
 
 
-from diffpy.pdffit2.version import __version__, __date__
-from diffpy.pdffit2.pdffit import PdfFit
 from diffpy.pdffit2.output import redirect_stdout
+from diffpy.pdffit2.pdffit import PdfFit
 from diffpy.pdffit2.pdffit2 import is_element
+from diffpy.pdffit2.version import __date__, __version__
 
 # silence pyflakes checker
 assert __version__ or True

--- a/src/diffpy/pdffit2/__init__.py
+++ b/src/diffpy/pdffit2/__init__.py
@@ -1,24 +1,34 @@
 #!/usr/bin/env python
 ##############################################################################
 #
-# (c) 2024 The Trustees of Columbia University in the City of New York.
-# All rights reserved.
+# pdffit2           by DANSE Diffraction group
+#                   Simon J. L. Billinge
+#                   (c) 2006 trustees of the Michigan State University.
+#                   All rights reserved.
 #
-# File coded by: Billinge Group members and community contributors.
+# File coded by:    Pavol Juhas
 #
-# See GitHub contributions for a more detailed list of contributors.
-# https://github.com/diffpy/diffpy.pdffit2/graphs/contributors
-#
-# See LICENSE.rst for license information.
+# See AUTHORS.txt for a list of people who contributed.
+# See LICENSE.txt for license information.
 #
 ##############################################################################
 
-"""PDFfit2 - real space structure refinement program."""
+"""PDFfit2 - real space structure refinement program.
+Classes:
+    PdfFit
+Routines:
+    redirect_stdout
+"""
 
-# package version
-from diffpy.pdffit2.version import __version__
 
-# silence the pyflakes syntax checker
+from diffpy.pdffit2.version import __version__, __date__
+from diffpy.pdffit2.pdffit import PdfFit
+from diffpy.pdffit2.output import redirect_stdout
+from diffpy.pdffit2.pdffit2 import is_element
+
+# silence pyflakes checker
 assert __version__ or True
+assert __date__ or True
+assert all((PdfFit, redirect_stdout, is_element))
 
 # End of file

--- a/src/diffpy/pdffit2/tests/__init__.py
+++ b/src/diffpy/pdffit2/tests/__init__.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python
+##############################################################################
+#
+# diffpy.pdffit2    by DANSE Diffraction group
+#                   Simon J. L. Billinge
+#                   (c) 2012 Trustees of the Columbia University
+#                   in the City of New York.  All rights reserved.
+#
+# File coded by:    Pavol Juhas
+#
+# See AUTHORS.txt for a list of people who contributed.
+# See LICENSE.txt for license information.
+#
+##############################################################################
+
+"""Unit tests for the diffpy.pdffit2 package.
+"""
+
+import unittest
+
+
+def testsuite(pattern=""):
+    """Create a unit tests suite for the diffpy.pdffit2 package.
+
+    Parameters
+    ----------
+    pattern : str, optional
+        Regular expression pattern for selecting test cases.
+        Select all tests when empty.  Ignore the pattern when
+        any of unit test modules fails to import.
+
+    Returns
+    -------
+    suite : `unittest.TestSuite`
+        The TestSuite object containing the matching tests.
+    """
+    import re
+    from itertools import chain
+    from os.path import dirname
+
+    from pkg_resources import resource_filename
+
+    loader = unittest.defaultTestLoader
+    thisdir = resource_filename(__name__, "")
+    depth = __name__.count(".") + 1
+    topdir = thisdir
+    for i in range(depth):
+        topdir = dirname(topdir)
+    suite_all = loader.discover(thisdir, pattern="*Test*.py", top_level_dir=topdir)
+    # always filter the suite by pattern to test-cover the selection code.
+    suite = unittest.TestSuite()
+    rx = re.compile(pattern)
+    tsuites = list(chain.from_iterable(suite_all))
+    tsok = all(isinstance(ts, unittest.TestSuite) for ts in tsuites)
+    if not tsok:  # pragma: no cover
+        return suite_all
+    tcases = chain.from_iterable(tsuites)
+    for tc in tcases:
+        tcwords = tc.id().split(".")
+        shortname = ".".join(tcwords[-3:])
+        if rx.search(shortname):
+            suite.addTest(tc)
+    # verify all tests are found for an empty pattern.
+    assert pattern or suite_all.countTestCases() == suite.countTestCases()
+    return suite
+
+
+def test():
+    """Execute all unit tests for the diffpy.pdffit2 package.
+
+    Returns
+    -------
+    result : `unittest.TestResult`
+    """
+    suite = testsuite()
+    runner = unittest.TextTestRunner()
+    result = runner.run(suite)
+    return result
+
+
+def testdeps():
+    """Execute all unit tests for diffpy.pdffit2 and its dependencies.
+
+    Returns
+    -------
+    result : `unittest.TestResult`
+    """
+    from importlib import import_module
+
+    modulenames = """
+        diffpy.pdffit2.tests
+        diffpy.structure.tests
+    """.split()
+    suite = unittest.TestSuite()
+    for mname in modulenames:
+        mod = import_module(mname)
+        suite.addTests(mod.testsuite())
+    runner = unittest.TextTestRunner()
+    result = runner.run(suite)
+    return result
+
+
+# End of file

--- a/src/diffpy/pdffit2/tests/debug.py
+++ b/src/diffpy/pdffit2/tests/debug.py
@@ -1,19 +1,20 @@
 #!/usr/bin/env python
 ##############################################################################
 #
-# (c) 2024 The Trustees of Columbia University in the City of New York.
-# All rights reserved.
+# diffpy.pdffit2    Complex Modeling Initiative
+#                   (c) 2016 Brookhaven Science Associates,
+#                   Brookhaven National Laboratory.
+#                   All rights reserved.
 #
-# File coded by: Billinge Group members and community contributors.
+# File coded by:    Pavol Juhas
 #
-# See GitHub contributions for a more detailed list of contributors.
-# https://github.com/diffpy/diffpy.pdffit2/graphs/contributors
-#
-# See LICENSE.rst for license information.
+# See AUTHORS.txt for a list of people who contributed.
+# See LICENSE.txt for license information.
 #
 ##############################################################################
 
-"""
+
+"""\
 Convenience module for debugging the unit tests using
 
 python -m diffpy.pdffit2.tests.debug

--- a/src/diffpy/pdffit2/tests/run.py
+++ b/src/diffpy/pdffit2/tests/run.py
@@ -1,34 +1,38 @@
 #!/usr/bin/env python
 ##############################################################################
 #
-# (c) 2024 The Trustees of Columbia University in the City of New York.
-# All rights reserved.
+# diffpy.pdffit2    by DANSE Diffraction group
+#                   Simon J. L. Billinge
+#                   (c) 2012 Trustees of the Columbia University
+#                   in the City of New York.  All rights reserved.
 #
-# File coded by: Billinge Group members and community contributors.
+# File coded by:    Pavol Juhas
 #
-# See GitHub contributions for a more detailed list of contributors.
-# https://github.com/diffpy/diffpy.pdffit2/graphs/contributors
-#
-# See LICENSE.rst for license information.
+# See AUTHORS.txt for a list of people who contributed.
+# See LICENSE.txt for license information.
 #
 ##############################################################################
+
 """Convenience module for executing all unit tests with
+
 python -m diffpy.pdffit2.tests.run
 """
 
-import sys
-
-import pytest
 
 if __name__ == "__main__":
-    # show output results from every test function
-    args = ["-v"]
-    # show the message output for skipped and expected failure tests
-    if len(sys.argv) > 1:
-        args.extend(sys.argv[1:])
-    print("pytest arguments: {}".format(args))
-    # call pytest and exit with the return code from pytest
-    exit_res = pytest.main(args)
-    sys.exit(exit_res)
+    import sys
+
+    # show warnings by default
+    if not sys.warnoptions:
+        import os
+        import warnings
+
+        warnings.simplefilter("default")
+        # also affect subprocesses
+        os.environ["PYTHONWARNINGS"] = "default"
+    from diffpy.pdffit2.tests import test
+
+    # produce zero exit code for a successful test
+    sys.exit(not test().wasSuccessful())
 
 # End of file

--- a/src/diffpy/pdffit2/version.py
+++ b/src/diffpy/pdffit2/version.py
@@ -1,26 +1,54 @@
 #!/usr/bin/env python
 ##############################################################################
 #
-# (c) 2024 The Trustees of Columbia University in the City of New York.
-# All rights reserved.
+# pdffit2           by DANSE Diffraction group
+#                   Simon J. L. Billinge
+#                   (c) 2008 trustees of the Michigan State University.
+#                   All rights reserved.
 #
-# File coded by: Billinge Group members and community contributors.
+# File coded by:    Pavol Juhas
 #
-# See GitHub contributions for a more detailed list of contributors.
-# https://github.com/diffpy/diffpy.pdffit2/graphs/contributors
-#
-# See LICENSE.rst for license information.
+# See AUTHORS.txt for a list of people who contributed.
+# See LICENSE.txt for license information.
 #
 ##############################################################################
 
-"""Definition of __version__."""
+"""
+Definition of __version__, __date__, __timestamp__, __git_commit__.
 
-#  We do not use the other three variables, but can be added back if needed.
-#  __all__ = ["__date__", "__git_commit__", "__timestamp__", "__version__"]
+Notes
+-----
+Variable `__gitsha__` is deprecated as of version 1.2.
+Use `__git_commit__` instead.
+"""
 
-# obtain version information
-from importlib.metadata import version
+__all__ = ["__date__", "__git_commit__", "__timestamp__", "__version__"]
 
-__version__ = version("diffpy.pdffit2")
+import os.path
+
+from pkg_resources import resource_filename
+
+# obtain version information from the version.cfg file
+cp = dict(version="", date="", commit="", timestamp="0")
+fcfg = resource_filename(__name__, "version.cfg")
+if not os.path.isfile(fcfg):  # pragma: no cover
+    from warnings import warn
+
+    warn('Package metadata not found, execute "./setup.py egg_info".')
+    fcfg = os.devnull
+with open(fcfg) as fp:
+    kwords = [[w.strip() for w in line.split(" = ", 1)] for line in fp if line[:1].isalpha() and " = " in line]
+assert all(w[0] in cp for w in kwords), "received unrecognized keyword"
+cp.update(kwords)
+
+__version__ = cp["version"]
+__date__ = cp["date"]
+__git_commit__ = cp["commit"]
+__timestamp__ = int(cp["timestamp"])
+
+# TODO remove deprecated __gitsha__ in version 1.3.
+__gitsha__ = __git_commit__
+
+del cp, fcfg, fp, kwords
 
 # End of file


### PR DESCRIPTION
Add back old files to make tests pass. Note: does not use pytest.
See screenshot. Do we want to fix deprecation warnings yet?
![Screenshot from 2024-07-22 17-11-25](https://github.com/user-attachments/assets/8a3a62aa-fb04-4d3f-bdc3-d12d0d12bd0f)
