### PR TITLE
Cookiecutting - fix editable mode build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,9 @@ classifiers = [
 Homepage = "https://github.com/diffpy/diffpy.pdffit2/"
 Issues = "https://github.com/diffpy/diffpy.pdffit2/issues/"
 
+[tools.setuptools]
+package-dir = {"" = "src"}
+
 [tool.setuptools-git-versioning]
 enabled = true
 template = "{tag}"

--- a/setup.py
+++ b/setup.py
@@ -1,71 +1,150 @@
 #!/usr/bin/env python
 
-# Extensions script for diffpy.pdffit2
+# Installation script for diffpy.pdffit2
 
-import glob
+"""PDFfit2 - real space structure refinement engine
+
+Packages:   diffpy.pdffit2
+Scripts:    pdffit2
+"""
+
+import os
+import re
 import sys
+import warnings
 
-from setuptools import Extension, setup
+from setuptools import Extension, find_packages, setup
 
-# Define extension arguments here
-ext_kws = {
-    "libraries": [],
-    "extra_compile_args": [],
-    "extra_link_args": [],
-    "include_dirs": [],
-}
+MYDIR = os.path.dirname(os.path.abspath(__file__))
+versioncfgfile = os.path.join(MYDIR, "src/diffpy/pdffit2/version.cfg")
+gitarchivecfgfile = os.path.join(MYDIR, ".gitarchive.cfg")
 
 
-# Figure out the tagged name of boost_python library.
-def get_boost_libraries():
-    """Check for installed boost_python shared library.
+# Helper functions -----------------------------------------------------------
 
-    Returns list of required boost_python shared libraries that are installed
-    on the system. If required libraries are not found, an Exception will be
-    thrown.
+
+def get_compiler_type():
+    """find compiler used for building extensions."""
+    cc_arg = [a for a in sys.argv if a.startswith("--compiler=")]
+    if cc_arg:
+        compiler_type = cc_arg[-1].split("=", 1)[1]
+    else:
+        from distutils.ccompiler import new_compiler
+
+        compiler_type = new_compiler().compiler_type
+    return compiler_type
+
+
+def get_gsl_config():
+    """Return dictionary with paths to GSL library."""
+    gslcfgpaths = [os.path.join(p, "gsl-config") for p in ([MYDIR] + os.environ["PATH"].split(os.pathsep))]
+    gslcfgpaths = [p for p in gslcfgpaths if os.path.isfile(p)]
+    rv = {"include_dirs": [], "library_dirs": []}
+    if not gslcfgpaths:
+        wmsg = "Cannot find gsl-config in {!r} nor in system PATH."
+        warnings.warn(wmsg.format(MYDIR))
+        return rv
+    gslcfg = gslcfgpaths[0]
+    with open(gslcfg) as fp:
+        txt = fp.read()
+    mprefix = re.search("(?m)^prefix=(.+)", txt)
+    minclude = re.search(r"(?m)^[^#]*\s-I(\S+)", txt)
+    mlibpath = re.search(r"(?m)^[^#]*\s-L(\S+)", txt)
+    if not mprefix:
+        emsg = "Cannot find 'prefix=' line in {}."
+        raise RuntimeError(emsg.format(gslcfg))
+    p = mprefix.group(1)
+    inc = minclude.group(1) if minclude else (p + "/include")
+    lib = mlibpath.group(1) if mlibpath else (p + "/lib")
+    rv["include_dirs"] += [inc]
+    rv["library_dirs"] += [lib]
+    return rv
+
+
+def get_gsl_config_win():
+    """Return dictionary with paths to GSL library, windwows version.
+    This version is installed with conda.
     """
-    baselib = "boost_python"
-    major, minor = (str(x) for x in sys.version_info[:2])
-    pytags = [major + minor, major, ""]
-    mttags = ["", "-mt"]
-    boostlibtags = [(pt + mt) for mt in mttags for pt in pytags] + [""]
-    from ctypes.util import find_library
-
-    for tag in boostlibtags:
-        lib = baselib + tag
-        found = find_library(lib)
-        if found:
-            break
-
-    # Show warning when library was not detected.
-    if not found:
-        import platform
-        import warnings
-
-        ldevname = "LIBRARY_PATH"
-        if platform.system() == "Darwin":
-            ldevname = "DYLD_FALLBACK_LIBRARY_PATH"
-        wmsg = ("Cannot detect name suffix for the %r library. " "Consider setting %s.") % (baselib, ldevname)
-        warnings.warn(wmsg)
-
-    libs = [lib]
-    return libs
+    conda_prefix = os.environ["CONDA_PREFIX"]
+    inc = os.path.join(conda_prefix, "Library", "include")
+    lib = os.path.join(conda_prefix, "Library", "lib")
+    rv = {"include_dirs": [], "library_dirs": []}
+    rv["include_dirs"] += [inc]
+    rv["library_dirs"] += [lib]
+    return rv
 
 
-def create_extensions():
-    "Initialize Extension objects for the setup function."
-    blibs = [n for n in get_boost_libraries() if n not in ext_kws["libraries"]]
-    ext_kws["libraries"] += blibs
-    ext = Extension("diffpy.pdffit2.pdffit2_ext", glob.glob("src/extensions/*.cpp"), **ext_kws)
-    return [ext]
+# ----------------------------------------------------------------------------
+
+# compile and link options
+define_macros = []
+os_name = os.name
+if os_name == "nt":
+    gcfg = get_gsl_config_win()
+else:
+    gcfg = get_gsl_config()
+include_dirs = [MYDIR] + gcfg["include_dirs"]
+library_dirs = []
+libraries = []
+extra_objects = []
+extra_compile_args = []
+extra_link_args = []
+
+compiler_type = get_compiler_type()
+if compiler_type in ("unix", "cygwin", "mingw32"):
+    extra_compile_args = ["-std=c++11", "-Wall", "-Wno-write-strings", "-O3", "-funroll-loops", "-ffast-math"]
+    extra_objects += ((p + "/libgsl.a") for p in gcfg["library_dirs"])
+elif compiler_type == "msvc":
+    define_macros += [("_USE_MATH_DEFINES", None)]
+    extra_compile_args = ["/EHs"]
+    libraries += ["gsl"]
+    library_dirs += gcfg["library_dirs"]
+# add optimization flags for other compilers if needed
 
 
-# Extensions not included in pyproject.toml
-setup_args = dict(
-    ext_modules=[],
+# define extension here
+pdffit2module = Extension(
+    "diffpy.pdffit2.pdffit2",
+    [
+        "src/extensions/pdffit2module/bindings.cc",
+        "src/extensions/pdffit2module/misc.cc",
+        "src/extensions/pdffit2module/pdffit2module.cc",
+        "src/extensions/pdffit2module/pyexceptions.cc",
+        "src/extensions/libpdffit2/Atom.cc",
+        "src/extensions/libpdffit2/LocalPeriodicTable.cc",
+        "src/extensions/libpdffit2/OutputStreams.cc",
+        "src/extensions/libpdffit2/PeriodicTable.cc",
+        "src/extensions/libpdffit2/PointsInSphere.cc",
+        "src/extensions/libpdffit2/StringUtils.cc",
+        "src/extensions/libpdffit2/fit.cc",
+        "src/extensions/libpdffit2/gaussj.cc",
+        "src/extensions/libpdffit2/metric.cc",
+        "src/extensions/libpdffit2/nrutil.cc",
+        "src/extensions/libpdffit2/output.cc",
+        "src/extensions/libpdffit2/parser.cc",
+        "src/extensions/libpdffit2/pdf.cc",
+        "src/extensions/libpdffit2/pdffit.cc",
+        "src/extensions/libpdffit2/pdflsmin.cc",
+        "src/extensions/libpdffit2/scatlen.cc",
+        "src/extensions/libpdffit2/stru.cc",
+    ],
+    include_dirs=include_dirs,
+    libraries=libraries,
+    library_dirs=library_dirs,
+    define_macros=define_macros,
+    extra_compile_args=extra_compile_args,
+    extra_link_args=extra_link_args,
+    extra_objects=extra_objects,
 )
 
+setup_args = dict(
+    packages=find_packages(where="src"),
+    package_dir={"": "src"},
+    ext_modules=[pdffit2module],
+    # scripts=[]
+)
 
 if __name__ == "__main__":
-    setup_args["ext_modules"] = create_extensions()
     setup(**setup_args)
+
+# End of file

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Installation script for diffpy.pdffit2
+# Extensions script for diffpy.pdffit2
 
 """PDFfit2 - real space structure refinement engine
 
@@ -141,7 +141,7 @@ setup_args = dict(
     packages=find_packages(where="src"),
     package_dir={"": "src"},
     ext_modules=[pdffit2module],
-    # scripts=[]
+    # scripts=[]    # place examples here
 )
 
 if __name__ == "__main__":

--- a/src/extensions/pdffit2module/misc.cc
+++ b/src/extensions/pdffit2module/misc.cc
@@ -30,9 +30,9 @@
 #include "misc.h"
 #include "pyexceptions.h"
 #include "PyFileStreambuf.h"
-#include "libpdffit2/StringUtils.h"
-#include "libpdffit2/LocalPeriodicTable.h"
-#include "libpdffit2/pdffit.h"
+#include "../libpdffit2/StringUtils.h"
+#include "../libpdffit2/LocalPeriodicTable.h"
+#include "../libpdffit2/pdffit.h"
 
 // ostream buffer used for engine output redirection
 PyFileStreambuf* py_stdout_streambuf = NULL;

--- a/src/extensions/pdffit2module/pdffit2module.cc
+++ b/src/extensions/pdffit2module/pdffit2module.cc
@@ -23,7 +23,7 @@
 
 #include "pyexceptions.h"
 #include "bindings.h"
-#include "libpdffit2/pdffit.h"
+#include "../libpdffit2/pdffit.h"
 
 using namespace std;
 


### PR DESCRIPTION
Fixed errors that prevented editable mode from being built.
- Removed use of boost.python to build extensions
- Updated paths of C++ code to account for the src/extensions directory