### PR TITLE
Add separate install instructions for macOS Arm64 users in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,30 +93,30 @@ Add the "conda-forge" channel by running the following command in a terminal:
 
         conda config --add channels conda-forge
 
-Create a new environment named ``diffpy.pdffit2_env`` and install ``diffpy.pdffit2`` ::
+Create a new environment named ``diffpy.pdffit2_env`` and install ``diffpy.pdffit2``: ::
 
         conda create -n diffpy.pdffit2_env diffpy.pdffit2
 
-Activate the environment ::
+Activate the environment: ::
 
         conda activate diffpy.pdffit2_env
 
-Confirm that the installation was successful ::
+Confirm that the installation was successful: ::
 
         python -c "import diffpy.pdffit2; print(diffpy.pdffit2.__version__)"
 
 macOS (Arm64)
 ~~~~~~~~~~~
 
-Create a new conda environment ``diffpy.pdffit2_env`` ::
+Create a new conda environment ``diffpy.pdffit2_env``: ::
 
         conda create -n diffpy.pdffit2_env python=3.12
 
-Install pdffit2 using ``pip`` to download and install the latest version from `Python Package Index <https://pypi.python.org>`_ ::
+Install pdffit2 using ``pip`` to download and install the latest version from `Python Package Index <https://pypi.python.org>`_: ::
 
         pip install diffpy.pdffit2
 
-Confirm that the installation was successful ::
+Confirm that the installation was successful: ::
 
         python -c "import diffpy.pdffit2; print(diffpy.pdffit2.__version__)"
 
@@ -130,7 +130,7 @@ For advanced users, obtain the source archive, and in the ``diffpy.pdffit2`` dir
                 --file requirements/conda.txt \
                 --file requirements/build.txt
 
-Run the following commands sequentially to activate the environment, build the package, and run unit tests ::
+Activate the environment, build the package, and run unit tests by following commands sequentially: ::
 
         conda activate diffpy.pdffit2_env
         pip install . --no-deps

--- a/README.rst
+++ b/README.rst
@@ -73,14 +73,6 @@ Installation
 ------------
 
 diffpy.pdffit2 supports Python 3.11 and 3.12
-the following external software:
-
-* ``setuptools`` - software distribution tools for Python
-* ``python-dev`` - header files for interfacing Python with C
-* ``GSL`` - GNU Scientific Library for C
-* ``g++`` - GNU C++ compiler
-* ``diffpy.structure`` - simple storage and manipulation of atomic
-  structures, https://github.com/diffpy/diffpy.structure
 
 Windows, macOS (non-Arm64), Linux
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -89,7 +81,7 @@ The preferred method is to use `Miniconda Python
 <https://docs.conda.io/projects/miniconda/en/latest/miniconda-install.html>`_
 and install from the "conda-forge" channel of Conda packages.
 
-Add the "conda-forge" channel by running the following command in a terminal:
+Add the "conda-forge" channel by running the following command in a terminal: ::
 
         conda config --add channels conda-forge
 

--- a/README.rst
+++ b/README.rst
@@ -72,7 +72,7 @@ If you use diffpy.pdffit2 in a scientific publication, we would like you to cite
 Installation
 ------------
 
-diffpy.pdffit2 requires Python 3.11 or later and
+diffpy.pdffit2 supports Python 3.11 and 3.12
 the following external software:
 
 * ``setuptools`` - software distribution tools for Python
@@ -82,47 +82,59 @@ the following external software:
 * ``diffpy.structure`` - simple storage and manipulation of atomic
   structures, https://github.com/diffpy/diffpy.structure
 
-----
+Windows, macOS (non-Arm64), Linux
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The preferred method is to use `Miniconda Python
 <https://docs.conda.io/projects/miniconda/en/latest/miniconda-install.html>`_
 and install from the "conda-forge" channel of Conda packages.
 
-To add "conda-forge" to the conda channels, run the following in a terminal. ::
+Add the "conda-forge" channel by running the following command in a terminal:
 
         conda config --add channels conda-forge
 
-We want to install our packages in a suitable conda environment.
-The following creates and activates a new environment named ``diffpy.pdffit2_env`` ::
+Create a new environment named ``diffpy.pdffit2_env`` and install ``diffpy.pdffit2`` ::
 
-        conda create -n diffpy.pdffit2_env python=3
+        conda create -n diffpy.pdffit2_env diffpy.pdffit2
+
+Activate the environment ::
+
         conda activate diffpy.pdffit2_env
 
-Then, to fully install ``diffpy.pdffit2`` in our active environment, run ::
+Confirm that the installation was successful ::
 
-        conda install diffpy.pdffit2
+        python -c "import diffpy.pdffit2; print(diffpy.pdffit2.__version__)"
 
-The less preferred approach is the install using ``pip`` to download and install the latest release from `Python Package Index <https://pypi.python.org>`_. In this case you currently have to build the codes on your computer from the sources and you will have to have a C++ installer available.
+macOS (Arm64)
+~~~~~~~~~~~
 
-To install the C++ compiler and required dependencies in your ``diffpy.pdffit2_env`` environment, type ::
+Create a new conda environment ``diffpy.pdffit2_env`` ::
 
-        conda install \
-          --file requirements/run.txt \
-          --file requirements/build.txt
+        conda create -n diffpy.pdffit2_env python=3.12
 
-And then type ::
+Install pdffit2 using ``pip`` to download and install the latest version from `Python Package Index <https://pypi.python.org>`_ ::
 
         pip install diffpy.pdffit2
 
-If you prefer to install from sources, use the above ``conda install \ ..`` instruction to install the dependencies in ``run.txt`` and ``build.txt`` in ``diffpy.pdffit2_env`` , obtain the source archive from
-`GitHub <https://github.com/diffpy/diffpy.pdffit2/>`_. Once installed, ``cd`` into your ``diffpy.pdffit2`` directory
-and run the following ::
-
-        pip install .
-
-To confirm that the installation was successful, run the following in a terminal ::
+Confirm that the installation was successful ::
 
         python -c "import diffpy.pdffit2; print(diffpy.pdffit2.__version__)"
+
+Build from source
+~~~~~~~~~~~~~~~~
+
+For advanced users, obtain the source archive, and in the ``diffpy.pdffit2`` directory, run ::
+
+        conda create -n diffpy.pdffit2_env python=3.12 \
+                --file requirements/test.txt \
+                --file requirements/conda.txt \
+                --file requirements/build.txt
+
+Run the following commands sequentially to activate the environment, build the package, and run unit tests ::
+
+        conda activate diffpy.pdffit2_env
+        pip install . --no-deps
+        pytest
 
 Support and Contribute
 ----------------------

--- a/news/readme-install.rst
+++ b/news/readme-install.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Separate installation instruction for macOS (Arm64) in READEM
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
Closes https://github.com/diffpy/diffpy.pdffit2/issues/86
Closes https://github.com/diffpy/diffpy.pdffit2/issues/24 


Here is the rendered version of the REAMDE: 

https://github.com/bobleesj/diffpy.pdffit2/tree/readme-install?tab=readme-ov-file#installation