### PR TITLE
fix: wheel for windows 

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -1,0 +1,84 @@
+name: Wheel builder
+
+on:
+  pull_request:
+  push:
+  workflow_dispatch:
+
+jobs:
+  build_wheels:
+
+    defaults:
+        run:
+          shell: bash -l {0}
+
+    name: Build wheel ${{ matrix.python[0] }}-${{ matrix.buildplat[0] }}
+    runs-on: ${{ matrix.buildplat[0] }}
+    strategy:
+      fail-fast: false
+      matrix:
+        buildplat:
+          - [ubuntu-latest, manylinux_x86_64]
+          - [macos-13, macosx_x86_64]
+          - [macos-14, macosx_arm64]
+          - [windows-latest, win_amd64]
+        python:
+          - ["3.11", "cp311"]
+          - ["3.12", "cp312"]
+
+    steps:
+      - name: Check out #${{ inputs.project }}
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python[0] }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python[0] }}
+
+      - name: Build wheels for Linux
+        if: runner.os == 'Linux'
+        uses: pypa/cibuildwheel@v2.21.1
+        env:
+          CIBW_BUILD: ${{ matrix.python[1] }}-${{ matrix.buildplat[1] }}
+          CIBW_BEFORE_BUILD: yum install -y gsl-devel && pip install -e .
+        with:
+          output-dir: wheelhouse
+
+      - name: Build wheels for macOS
+        if: runner.os == 'macOS'
+        uses: pypa/cibuildwheel@v2.21.1
+        env:
+          CIBW_BUILD: ${{ matrix.python[1] }}-${{ matrix.buildplat[1] }}
+          MACOSX_DEPLOYMENT_TARGET: 13.0
+          CIBW_BEFORE_BUILD: brew install gsl && pip install -e .
+        with:
+          output-dir: wheelhouse
+
+      - name: Set up conda for Windows
+        if: runner.os == 'Windows'
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          activate-environment: gsl
+          auto-update-conda: true
+          environment-file: environment.yml
+          auto-activate-base: false
+
+      - name: install gsl for Windows
+        if: runner.os == 'Windows'
+        run: |
+          conda config --set always_yes yes --set changeps1 no
+          conda install gsl
+
+      - name: Build wheels for Windows
+        if: runner.os == 'Windows'
+        uses: pypa/cibuildwheel@v2.21.1
+        env:
+          CIBW_BUILD: ${{ matrix.python[1] }}-${{ matrix.buildplat[1] }}
+          CONDA_PREFIX: ${{ env.CONDA_PREFIX }}
+        with:
+          output-dir: wheelhouse
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.python[0] }}-${{ matrix.buildplat[0] }}
+          path: ./wheelhouse/*.whl

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,8 @@ Scripts:    pdffit2
 import glob
 import os
 import re
-import sys
 import shutil
+import sys
 import warnings
 
 from setuptools import Extension, setup
@@ -84,17 +84,19 @@ def get_gsl_config_win():
 
     return {"include_dirs": [inc], "library_dirs": [lib]}
 
+
 class CustomBuildExt(build_ext):
     def run(self):
         super().run()
         gsl_path = os.environ.get("GSL_PATH") or os.path.join(os.environ.get("CONDA_PREFIX", ""), "Library")
-        
+
         bin_path = os.path.join(gsl_path, "bin")
         dest_path = os.path.join(self.build_lib, "diffpy", "pdffit2")
         os.makedirs(dest_path, exist_ok=True)
 
         for dll_file in glob.glob(os.path.join(bin_path, "gsl*.dll")):
             shutil.copy(dll_file, dest_path)
+
 
 # ----------------------------------------------------------------------------
 

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ import shutil
 import warnings
 
 from setuptools import Extension, setup
+from setuptools.command.build_ext import build_ext
 
 # Use this version when git data are not available, like in git zip archive.
 # Update when tagging a new release.

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ import glob
 import os
 import re
 import sys
+import shutil
 import warnings
 
 from setuptools import Extension, setup
@@ -82,6 +83,17 @@ def get_gsl_config_win():
 
     return {"include_dirs": [inc], "library_dirs": [lib]}
 
+class CustomBuildExt(build_ext):
+    def run(self):
+        super().run()
+        gsl_path = os.environ.get("GSL_PATH") or os.path.join(os.environ.get("CONDA_PREFIX", ""), "Library")
+        
+        bin_path = os.path.join(gsl_path, "bin")
+        dest_path = os.path.join(self.build_lib, "diffpy", "pdffit2")
+        os.makedirs(dest_path, exist_ok=True)
+
+        for dll_file in glob.glob(os.path.join(bin_path, "gsl*.dll")):
+            shutil.copy(dll_file, dest_path)
 
 # ----------------------------------------------------------------------------
 
@@ -134,6 +146,7 @@ def create_extensions():
 
 setup_args = dict(
     ext_modules=[],
+    cmdclass={"build_ext": CustomBuildExt},
 )
 
 if __name__ == "__main__":


### PR DESCRIPTION
@sbillinge This should fix diffpy/diffpy.pdfgui#238 and diffpy/diffpy.pdfgui#240 after another pypi release. Before merging this the workflow file still need to be changed. The one attached here is just for showing it works. 

@bobleesj Can you help merging this workflow file into the release-script central workflow? Thanks!

These are the local test of the wheel produced [here](https://github.com/Tieqiong/diffpy.pdffit2/actions/runs/12577399053)

Windows with python3.12:
![image](https://github.com/user-attachments/assets/81a828b9-9a21-4f56-97c7-15afe23702df)

Linux with python3.12:
<img width="934" alt="image" src="https://github.com/user-attachments/assets/c0730cb6-80d2-4f9a-9232-84b216b27c75" />

Mac Arm with python3.12:
<img width="838" alt="image" src="https://github.com/user-attachments/assets/88f21769-ff5c-4db6-9506-ffe80c0d9237" />
