### PR TITLE
fix: correct release date

### DIFF
--- a/news/date.rst
+++ b/news/date.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fix missing `__date__`, use PyPI release date.
+
+**Security:**
+
+* <news item>

--- a/src/diffpy/pdffit2/version.py
+++ b/src/diffpy/pdffit2/version.py
@@ -14,15 +14,46 @@
 ##############################################################################
 """Definition of __version__."""
 
-#  We do not use the other three variables, but can be added back if needed.
-__all__ = ["__date__", "__git_commit__", "__timestamp__", "__version__"]
+import datetime
+from importlib.metadata import distribution, version
+from pathlib import Path
+import urllib.request
+import json
 
-# obtain version information
-from importlib.metadata import version
+
+def get_pypi_release_date(package_name, timeout=5):
+    package_file = Path(__file__).resolve()
+
+    try:
+        with open(package_file, "r", encoding="utf-8") as f:
+            lines = f.readlines()
+        for line in reversed(lines):
+            if line.startswith("# Release date:"):
+                return line.split(":", 1)[1].strip()
+
+        url = f"https://pypi.org/pypi/{package_name}/json"
+        with urllib.request.urlopen(url, timeout=timeout) as response:
+            data = json.loads(response.read().decode('utf-8'))
+
+        installed_version = version(package_name)
+        release_data = data["releases"].get(installed_version, [])
+        if not release_data:
+            raise ValueError(f"No release data found for version {installed_version}")
+
+        release_date_str = release_data[-1]["upload_time"]
+        release_date = datetime.datetime.fromisoformat(release_date_str).date()
+
+        with open(package_file, "a", encoding="utf-8") as f:
+            f.write(f"\n# Release date: {release_date}")
+
+    except (ValueError, OSError) as e:
+        print(f"Warning: Could not fetch release date from PyPI: {e}")
+        release_date = datetime.datetime.fromtimestamp(package_file.stat().st_ctime).isoformat()
+
+    return str(release_date)
+
 
 __version__ = version("diffpy.pdffit2")
-__date__ = __all__[0]
-__git_commit__ = __all__[1]
-__timestamp__ = __all__[2]
+__date__ = get_pypi_release_date("diffpy.pdffit2")
 
 # End of file

--- a/src/diffpy/pdffit2/version.py
+++ b/src/diffpy/pdffit2/version.py
@@ -17,7 +17,7 @@
 import datetime
 import json
 import urllib.request
-from importlib.metadata import distribution, version
+from importlib.metadata import version
 from pathlib import Path
 
 

--- a/src/diffpy/pdffit2/version.py
+++ b/src/diffpy/pdffit2/version.py
@@ -15,10 +15,10 @@
 """Definition of __version__."""
 
 import datetime
+import json
+import urllib.request
 from importlib.metadata import distribution, version
 from pathlib import Path
-import urllib.request
-import json
 
 
 def get_pypi_release_date(package_name, timeout=5):
@@ -33,7 +33,7 @@ def get_pypi_release_date(package_name, timeout=5):
 
         url = f"https://pypi.org/pypi/{package_name}/json"
         with urllib.request.urlopen(url, timeout=timeout) as response:
-            data = json.loads(response.read().decode('utf-8'))
+            data = json.loads(response.read().decode("utf-8"))
 
         installed_version = version(package_name)
         release_data = data["releases"].get(installed_version, [])


### PR DESCRIPTION
address #118
@sbillinge please check this and decide if it's the good way, thanks!

I think this might be the easiest way to provide the release date. Whenever the installed package use `__date__` for the first time (i.e. creating a `PdfFit` object), it will check the `pypi` release online, get the release date of that version, and save the date at the end of `version.py` as a line of comment. After this, it will only get `__date__` by parsing this comment line. When the package gets an update, `version.py` will be removed and reinstalled, leaving room for the new date. Any error will fall the date back to the creation date of the package (install date).

This is an unusual approach, as it modify the package file during the user's first successful use. This means if the user does some hash check after using it (which is very unlikely) it will not pass the check. (A bit like a wax seal...)

The more conventional way as suggested in the issue, pulling date of the latest git tag during release CI, could work. But the changes would be less easy to make and test. It will also affect all other packages using the CI, which is not necessary.