### PR TITLE
feat: add option to skip copyright header

### DIFF
--- a/news/intro.rst
+++ b/news/intro.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Add skip intro option when initializing the `PdfFit` class, with related docstrings and tests.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/intro.rst
+++ b/news/intro.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* Add skip intro option when initializing the `PdfFit` class, with related docstrings and tests.
+* Option to skip printing of introductory information when initializing the `PdfFit` class.
 
 **Changed:**
 

--- a/src/diffpy/pdffit2/pdffit.py
+++ b/src/diffpy/pdffit2/pdffit.py
@@ -1252,13 +1252,14 @@ class PdfFit(object):
 
     # End refinable variables.
 
-    def __init__(self):
+    def __init__(self, intro=True):
 
         self.stru_files = []
         self.data_files = []
 
         self._handle = pdffit2.create()
-        self.intro()
+        if intro:
+            self.intro()
         return
 
     def __getRef(self, var_string):

--- a/src/diffpy/pdffit2/pdffit.py
+++ b/src/diffpy/pdffit2/pdffit.py
@@ -104,7 +104,6 @@ __intro_message__ = """
 
 
 class PdfFit(object):
-    """Create PdfFit object."""
 
     # constants and enumerators from pdffit.h:
     # selection of all atoms
@@ -1253,6 +1252,22 @@ class PdfFit(object):
     # End refinable variables.
 
     def __init__(self, intro=True):
+        """Initialize the Pdffit class, create a new PdfFit object.
+
+        Parameters
+        ----------
+        intro : bool, optional
+            If True, display an introduction message. Default is True.
+
+        Attributes
+        ----------
+        stru_files : list
+            A list to store structure files.
+        data_files : list
+            A list to store data files.
+        _handle : PyCapsule
+            A python capsules to retrieve the printer to PdfFit object.
+        """
 
         self.stru_files = []
         self.data_files = []

--- a/src/diffpy/pdffit2/pdffit.py
+++ b/src/diffpy/pdffit2/pdffit.py
@@ -104,6 +104,15 @@ __intro_message__ = """
 
 
 class PdfFit(object):
+    """Class for PdfFit.
+
+    Attributes
+    ----------
+    stru_files : list
+        The list to store structure files.
+    data_files : list
+        The list to store data files.
+    """
 
     # constants and enumerators from pdffit.h:
     # selection of all atoms
@@ -1251,29 +1260,21 @@ class PdfFit(object):
 
     # End refinable variables.
 
-    def __init__(self, intro=True):
+    def __init__(self, create_intro=True):
         """Initialize the Pdffit class, create a new PdfFit object.
 
         Parameters
         ----------
-        intro : bool, optional
-            If True, display an introduction message. Default is True.
-
-        Attributes
-        ----------
-        stru_files : list
-            A list to store structure files.
-        data_files : list
-            A list to store data files.
-        _handle : PyCapsule
-            A python capsules to retrieve the printer to PdfFit object.
+        create_intro : bool, optional
+            The flag to control the display of an introduction message.
+            If True, display an introduction message, else not. Default is True.
         """
 
         self.stru_files = []
         self.data_files = []
 
         self._handle = pdffit2.create()
-        if intro:
+        if create_intro:
             self.intro()
         return
 

--- a/tests/test_pdffit.py
+++ b/tests/test_pdffit.py
@@ -702,56 +702,69 @@ class TestPdfFit(unittest.TestCase):
             self.assertEqual(1, pf.getvar(pf.occ(i)))
         return
 
+    #   def test_pscale(self):
+    #       """check PdfFit.pscale()
+    #       """
+    #       return
+    #
+    #   def test_pscale(self):
+    #       """check PdfFit.pscale()
+    #       """
+    #       return
+    #
+    #   def test_sratio(self):
+    #       """check PdfFit.sratio()
+    #       """
+    #       return
+    #
+    #   def test_delta1(self):
+    #       """check PdfFit.delta1()
+    #       """
+    #       return
+    #
+    #   def test_delta2(self):
+    #       """check PdfFit.delta2()
+    #       """
+    #       return
+    #
+    #   def test_dscale(self):
+    #       """check PdfFit.dscale()
+    #       """
+    #       return
+    #
+    #   def test_qdamp(self):
+    #       """check PdfFit.qdamp()
+    #       """
+    #       return
+    #
+    #   def test_qbroad(self):
+    #       """check PdfFit.qbroad()
+    #       """
+    #       return
+    #
+    #   def test_rcut(self):
+    #       """check PdfFit.rcut()
+    #       """
+    #       return
+    #
 
-#   def test_pscale(self):
-#       """check PdfFit.pscale()
-#       """
-#       return
-#
-#   def test_pscale(self):
-#       """check PdfFit.pscale()
-#       """
-#       return
-#
-#   def test_sratio(self):
-#       """check PdfFit.sratio()
-#       """
-#       return
-#
-#   def test_delta1(self):
-#       """check PdfFit.delta1()
-#       """
-#       return
-#
-#   def test_delta2(self):
-#       """check PdfFit.delta2()
-#       """
-#       return
-#
-#   def test_dscale(self):
-#       """check PdfFit.dscale()
-#       """
-#       return
-#
-#   def test_qdamp(self):
-#       """check PdfFit.qdamp()
-#       """
-#       return
-#
-#   def test_qbroad(self):
-#       """check PdfFit.qbroad()
-#       """
-#       return
-#
-#   def test_rcut(self):
-#       """check PdfFit.rcut()
-#       """
-#       return
-#
-#   def test___init__(self):
-#       """check PdfFit.__init__()
-#       """
-#       return
+    def test___init__(self):
+        """Check PdfFit.__init__()"""
+        P = PdfFit()
+        self.assertEqual([], P.stru_files)
+        self.assertEqual([], P.data_files)
+
+        output_true = self.capture_output(PdfFit, intro=True).strip()
+        output_false = self.capture_output(PdfFit, intro=False).strip()
+
+        import diffpy.pdffit2.pdffit as pdffit
+
+        self.assertEqual(len(output_true), len(pdffit.__intro_message__.strip()))
+        self.assertEqual(len(output_false), 0)
+
+        return
+
+
 #
 #   def test__PdfFit__getRef(self):
 #       """check PdfFit._PdfFit__getRef()

--- a/tests/test_pdffit.py
+++ b/tests/test_pdffit.py
@@ -750,16 +750,10 @@ class TestPdfFit(unittest.TestCase):
 
     def test___init__(self):
         """Check PdfFit.__init__()"""
-        P = PdfFit()
-        self.assertEqual([], P.stru_files)
-        self.assertEqual([], P.data_files)
+        output_true = self.capture_output(PdfFit, create_intro=True).strip()
+        output_false = self.capture_output(PdfFit, create_intro=False).strip()
 
-        output_true = self.capture_output(PdfFit, intro=True).strip()
-        output_false = self.capture_output(PdfFit, intro=False).strip()
-
-        import diffpy.pdffit2.pdffit as pdffit
-
-        self.assertEqual(len(output_true), len(pdffit.__intro_message__.strip()))
+        self.assertGreater(len(output_true), 0)
         self.assertEqual(len(output_false), 0)
 
         return


### PR DESCRIPTION
closes #25 

@8bitsam @matthewcarbone May I ask if this solve the problem? A use case to skip the copyright:
```
P = PdfFit(intro=False)
```
@sbillinge please review, thanks!