### PR TITLE
fix: build sdist failing

### DIFF
--- a/.github/workflows/sdist.yml
+++ b/.github/workflows/sdist.yml
@@ -1,0 +1,23 @@
+name: Tests build sdist
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build_sdist:
+    name: Build diffpy.pdffit2 sdist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Build sdist
+        run: pipx run build --sdist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cibw-sdist
+          path: ./dist/*.tar.gz

--- a/news/sdist.rst
+++ b/news/sdist.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Changed setup.py to lazy evaluate gsl installation.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
@sbillinge please check, thanks

Apply lazy evaluation to prevents it failing when simply build sdist (workflow attached too to test in `diffpy.pdffit2`, need to remove before merge)