### PR TITLE
skpkg: migrate documentation and rst files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ __pycache__/
 .Python
 env/
 build/
+_build/
 develop-eggs/
 dist/
 downloads/
@@ -90,10 +91,3 @@ target/
 
 # Ipython Notebook
 .ipynb_checkpoints
-
-# version information
-setup.cfg
-/src/diffpy/*/version.cfg
-
-# Rever
-rever/

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,5 @@
 =============
-Release Notes
+Release notes
 =============
 
 .. current developments

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -65,7 +65,7 @@ Release notes
 * No notable functional changes from 1.4.1
 
 1.4.4rc0
-=====
+========
 
 **Fixed:**
 

--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -1,6 +1,4 @@
-License
-#######
-
+BSD 3-Clause License
 This program is part of the DiffPy and DANSE open-source projects
 and is available subject to the conditions and terms laid out below.
 
@@ -13,7 +11,7 @@ the following paper in your publication:
         in crystals (https://stacks.iop.org/0953-8984/19/335219), *J. Phys.: Condens. Matter*, 19, 335219 (2007)
 
 Copyright 2006-2007, Board of Trustees of Michigan State University,
-Copyright 2008-2024, Board of Trustees of Columbia University in the
+Copyright 2008-2025, Board of Trustees of Columbia University in the
 city of New York.  (Copyright holder indicated in each source file).
 
 For more information please visit the project web-page:
@@ -21,32 +19,26 @@ For more information please visit the project web-page:
 or email Prof. Simon Billinge at sb2896@columbia.edu
 
 Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions
-are met:
+modification, are permitted provided that the following conditions are met:
 
-  * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
 
-  * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
 
-  * Neither the name of the copyright holder nor the names of its
-    contributors may be used to endorse or promote products derived from
-    this software without specific prior written permission.
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY COPYRIGHT HOLDER "AS IS".  COPYRIGHT HOLDER
-EXPRESSLY DISCLAIMS ANY AND ALL WARRANTIES AND CONDITIONS, EITHER
-EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY, TITLE, FITNESS, ADEQUACY OR SUITABILITY
-FOR A PARTICULAR PURPOSE, AND ANY WARRANTIES OF FREEDOM FROM
-INFRINGEMENT OF ANY DOMESTIC OR FOREIGN PATENT, COPYRIGHTS, TRADE
-SECRETS OR OTHER PROPRIETARY RIGHTS OF ANY PARTY.  IN NO EVENT SHALL
-COPYRIGHT HOLDER BE LIABLE TO ANY PARTY FOR ANY DIRECT, INDIRECT,
-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
-USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
-THIS SOFTWARE OR RELATING TO THIS AGREEMENT, EVEN IF ADVISED OF THE
-POSSIBILITY OF SUCH DAMAGE.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@
         :target: https://diffpy.github.io/diffpy.pdffit2
         :height: 100px
 
-|PyPi| |Forge| |PythonVersion| |PR|
+|PyPI| |Forge| |PythonVersion| |PR|
 
 |CI| |Codecov| |Black| |Tracking|
 
@@ -26,7 +26,7 @@
 
 .. |PR| image:: https://img.shields.io/badge/PR-Welcome-29ab47ff
 
-.. |PyPi| image:: https://img.shields.io/pypi/v/diffpy.pdffit2
+.. |PyPI| image:: https://img.shields.io/pypi/v/diffpy.pdffit2
         :target: https://pypi.org/project/diffpy.pdffit2/
 
 .. |PythonVersion| image:: https://img.shields.io/pypi/pyversions/diffpy.pdffit2
@@ -87,19 +87,17 @@ The preferred method is to use `Miniconda Python
 <https://docs.conda.io/projects/miniconda/en/latest/miniconda-install.html>`_
 and install from the "conda-forge" channel of Conda packages.
 
-Add the "conda-forge" channel by running the following command in a terminal: ::
+To add "conda-forge" to the conda channels, run the following in a terminal. ::
 
         conda config --add channels conda-forge
 
-Create a new environment named ``diffpy.pdffit2_env`` and install ``diffpy.pdffit2``: ::
+We want to install our packages in a suitable conda environment.
+The following creates and activates a new environment named ``diffpy.pdffit2_env`` ::
 
         conda create -n diffpy.pdffit2_env diffpy.pdffit2
-
-Activate the environment: ::
-
         conda activate diffpy.pdffit2_env
 
-Confirm that the installation was successful: ::
+To confirm that the installation was successful, type ::
 
         python -c "import diffpy.pdffit2; print(diffpy.pdffit2.__version__)"
 
@@ -118,25 +116,20 @@ Install pdffit2 using ``pip`` to download and install the latest version from `P
 
         pip install diffpy.pdffit2
 
-Confirm that the installation was successful: ::
+To confirm that the installation was successful, type ::
 
         python -c "import diffpy.pdffit2; print(diffpy.pdffit2.__version__)"
 
-Build from source
-~~~~~~~~~~~~~~~~~
+If you prefer to install from sources, after installing the dependencies, obtain the source archive from
+`GitHub <https://github.com/diffpy/diffpy.pdffit2/>`_. Once installed, ``cd`` into your ``diffpy.pdffit2`` directory
+and run the following ::
 
-For advanced users, obtain the source archive, and in the ``diffpy.pdffit2`` directory, run ::
+        pip install .
 
-        conda create -n diffpy.pdffit2_env python=3.13 \
-                --file requirements/test.txt \
-                --file requirements/conda.txt \
-                --file requirements/build.txt
+Getting Started
+---------------
 
-Activate the environment, build the package, and run unit tests by following commands sequentially: ::
-
-        conda activate diffpy.pdffit2_env
-        pip install . --no-deps
-        pytest
+You may consult our `online documentation <https://diffpy.github.io/diffpy.pdffit2>`_ for tutorials and API references.
 
 Support and Contribute
 ----------------------
@@ -182,4 +175,9 @@ Before contributing, please read our `Code of Conduct <https://github.com/diffpy
 Contact
 -------
 
-For more information on diffpy.pdffit2 please visit the project `web-page <https://diffpy.github.io/>`_ or email Prof. Simon Billinge at sb2896@columbia.edu.
+For more information on diffpy.pdffit2 please visit the project `web-page <https://diffpy.github.io/>`_ or email Simon Billinge at sb2896@columbia.edu.
+
+Acknowledgements
+----------------
+
+``diffpy.pdffit2`` is built and maintained with `scikit-package <https://scikit-package.github.io/scikit-package/>`_.

--- a/doc/source/api/diffpy.pdffit2.rst
+++ b/doc/source/api/diffpy.pdffit2.rst
@@ -1,7 +1,9 @@
 :tocdepth: -1
 
-diffpy.pdffit2 package
-======================
+|title|
+=======
+
+.. |title| replace:: diffpy.pdffit2 package
 
 .. automodule:: diffpy.pdffit2
     :members:

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -53,6 +53,10 @@ extensions = [
     "m2r",
 ]
 
+autodoc_mock_imports = [
+    "diffpy.pdffit2.pdffit2",
+]
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -4,90 +4,49 @@
 
 .. |title| replace:: diffpy.pdffit2 documentation
 
-diffpy.pdffit2 - PDFfit2 - real space structure refinement program.
+``diffpy.pdffit2`` - PDFfit2 - real space structure refinement program.
 
-| Software version |release|.
+| Software version |release|
 | Last updated |today|.
 
-The diffpy.pdffit2 package provides functions for the calculation and
-refinement of atomic Pair Distribution Functions (PDF) from crystal
-structure models.  It is used as a computational engine by PDFgui. All
-refinements possible in PDFgui can be done by writing python scripts
-directly with diffpy.pdffit2,
-although less conveniently and with a fair knowledge of Python.
-However, we recommend using `diffpy-cmi
-<https://www.diffpy.org/products/diffpycmi/index.html>`_ for carrying
-out more advanced, python-scripted refinements of nanostructure.
+===============
+Getting started
+===============
 
-The PDFfit2 package includes an extension for the interactive `IPython
-<http://ipython.org>`_ shell, these days commonly used within
-Jupyter notebooks, which tries to mimic the old PDFFIT
-program.  To start IPython with this extension and also with plotting
-functions enabled, use ::
+Welcome to the ``diffpy.pdffit2`` documentation!
 
-   ipython --ext=diffpy.pdffit2.ipy_ext --pylab
-
-The IPython extension is suitable for interactive use, however
-refinement scripts should be preferably written as a standard
-Python code.  This is more reliable and needs only a few extra
-statements.
+To get started, please visit the :ref:`Getting started <getting-started>` page.
 
 =======
 Authors
 =======
 
-This code was derived from the first `PDFFIT
-<https://doi.org/10.1107/S0021889899003532>`_ program written by Thomas Proffen
-and Simon Billinge, which was a FORTRAN implementation of the original
-"Real-space Rietveld" code
-written by Simon Billinge (Billinge, S. J. L. “Real-space Rietveld: full profile structure refinement of the atomic pair distribution
-function”. In: Local Structure from Diffraction. Ed. by S. J. L. Billinge and M. F. Thorpe. New York:
-Plenum, 1998, p. 137).
-The sources were converted to C++ by Jacques Bloch and then extensively hacked,
-extended and purged from most glaring bugs by Chris Farrow and Pavol Juhas.
-This code is currently maintained as part of the DiffPy project to create
-python modules for structure investigations from diffraction data.
-
-The DiffPy team is located in the Billinge-group at the Applied Physics
-and Applied Mathematics Department of the Columbia University in New York.
-Previous significant contributors to this code were made by
-
-   Pavol Juhas,  Chris Farrow, Jacques Bloch, Wenduo Zhou
-
-with more recent contributions from Billinge-group members.
-For a more detailed list of contributors see
+``diffpy.pdffit2`` is developed by Billinge group and community members.. The maintainer for this project is Simon Billinge. For a detailed list of contributors see
 https://github.com/diffpy/diffpy.pdffit2/graphs/contributors.
-
-
-=========
-Reference
-=========
-
-If you use this program for a scientific research that leads to publication,
-we ask that you acknowledge use of the program by citing the following paper
-in your publication:
-
-   C. L. Farrow, P. Juhás, J. W. Liu, D. Bryndin, E. S. Božin, J. Bloch, Th. Proffen
-   and S. J. L. Billinge, PDFfit2 and PDFgui: computer programs for studying nanostructure
-   in crystals (https://stacks.iop.org/0953-8984/19/335219), *J. Phys.: Condens. Matter*, 19, 335219 (2007)
 
 ============
 Installation
 ============
 
-Please see the `README <https://github.com/diffpy/diffpy.pdffit2#installation>`_
+See the `README <https://github.com/diffpy/diffpy.pdffit2#installation>`_
 file included with the distribution.
+
+================
+Acknowledgements
+================
+
+``diffpy.pdffit2`` is built and maintained with `scikit-package <https://scikit-package.github.io/scikit-package/>`_.
 
 =================
 Table of contents
 =================
 .. toctree::
-   :titlesonly:
+   :maxdepth: 2
 
-   license
-   release
-   examples
+   getting-started
    Package API <api/diffpy.pdffit2>
+   release
+   license
 
 =======
 Indices

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -9,20 +9,67 @@
 | Software version |release|
 | Last updated |today|.
 
-===============
-Getting started
-===============
+The diffpy.pdffit2 package provides functions for the calculation and
+refinement of atomic Pair Distribution Functions (PDF) from crystal
+structure models.  It is used as a computational engine by PDFgui. All
+refinements possible in PDFgui can be done by writing python scripts
+directly with diffpy.pdffit2,
+although less conveniently and with a fair knowledge of Python.
+However, we recommend using `diffpy-cmi
+<https://www.diffpy.org/products/diffpycmi/index.html>`_ for carrying
+out more advanced, python-scripted refinements of nanostructure.
 
-Welcome to the ``diffpy.pdffit2`` documentation!
+The PDFfit2 package includes an extension for the interactive `IPython
+<http://ipython.org>`_ shell, these days commonly used within
+Jupyter notebooks, which tries to mimic the old PDFFIT
+program.  To start IPython with this extension and also with plotting
+functions enabled, use ::
 
-To get started, please visit the :ref:`Getting started <getting-started>` page.
+   ipython --ext=diffpy.pdffit2.ipy_ext --pylab
+
+The IPython extension is suitable for interactive use, however
+refinement scripts should be preferably written as a standard
+Python code.  This is more reliable and needs only a few extra
+statements.
 
 =======
 Authors
 =======
 
-``diffpy.pdffit2`` is developed by Billinge group and community members.. The maintainer for this project is Simon Billinge. For a detailed list of contributors see
+This code was derived from the first `PDFFIT
+<https://doi.org/10.1107/S0021889899003532>`_ program written by Thomas Proffen
+and Simon Billinge, which was a FORTRAN implementation of the original
+"Real-space Rietveld" code
+written by Simon Billinge (Billinge, S. J. L. “Real-space Rietveld: full profile structure refinement of the atomic pair distribution
+function”. In: Local Structure from Diffraction. Ed. by S. J. L. Billinge and M. F. Thorpe. New York:
+Plenum, 1998, p. 137).
+The sources were converted to C++ by Jacques Bloch and then extensively hacked,
+extended and purged from most glaring bugs by Chris Farrow and Pavol Juhas.
+This code is currently maintained as part of the DiffPy project to create
+python modules for structure investigations from diffraction data.
+
+The DiffPy team is located in the Billinge-group at the Applied Physics
+and Applied Mathematics Department of the Columbia University in New York.
+Previous significant contributors to this code were made by
+
+   Pavol Juhas,  Chris Farrow, Jacques Bloch, Wenduo Zhou
+
+with more recent contributions from Billinge-group members.
+For a more detailed list of contributors see
 https://github.com/diffpy/diffpy.pdffit2/graphs/contributors.
+
+
+=========
+Reference
+=========
+
+If you use this program for a scientific research that leads to publication,
+we ask that you acknowledge use of the program by citing the following paper
+in your publication:
+
+   C. L. Farrow, P. Juhás, J. W. Liu, D. Bryndin, E. S. Božin, J. Bloch, Th. Proffen
+   and S. J. L. Billinge, PDFfit2 and PDFgui: computer programs for studying nanostructure
+   in crystals (https://stacks.iop.org/0953-8984/19/335219), *J. Phys.: Condens. Matter*, 19, 335219 (2007)
 
 ============
 Installation
@@ -41,9 +88,11 @@ Acknowledgements
 Table of contents
 =================
 .. toctree::
-   :maxdepth: 2
+   :titlesonly:
 
-   getting-started
+   license
+   release
+   examples
    Package API <api/diffpy.pdffit2>
    release
    license

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -90,8 +90,6 @@ Table of contents
 .. toctree::
    :titlesonly:
 
-   license
-   release
    examples
    Package API <api/diffpy.pdffit2>
    release

--- a/doc/source/license.rst
+++ b/doc/source/license.rst
@@ -23,9 +23,7 @@ Copyright 2006-2007, Board of Trustees of Michigan State University,
 Copyright 2008-2025, Board of Trustees of Columbia University in the
 city of New York.  (Copyright holder indicated in each source file).
 
-For more information please visit the project web-page:
-    http://www.diffpy.org/
-or email Prof. Simon Billinge at sb2896@columbia.edu
+For more information please visit the project web-page: http://www.diffpy.org/ or email Prof. Simon Billinge at sb2896@columbia.edu
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/doc/source/license.rst
+++ b/doc/source/license.rst
@@ -5,6 +5,9 @@
 License
 #######
 
+OPEN SOURCE LICENSE AGREEMENT
+=============================
+BSD 3-Clause License
 This program is part of the DiffPy and DANSE open-source projects
 and is available subject to the conditions and terms laid out below.
 
@@ -17,7 +20,7 @@ the following paper in your publication:
         in crystals (https://stacks.iop.org/0953-8984/19/335219), *J. Phys.: Condens. Matter*, 19, 335219 (2007)
 
 Copyright 2006-2007, Board of Trustees of Michigan State University,
-Copyright 2008-|year|, Board of Trustees of Columbia University in the
+Copyright 2008-2025, Board of Trustees of Columbia University in the
 city of New York.  (Copyright holder indicated in each source file).
 
 For more information please visit the project web-page:
@@ -25,32 +28,26 @@ For more information please visit the project web-page:
 or email Prof. Simon Billinge at sb2896@columbia.edu
 
 Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions
-are met:
+modification, are permitted provided that the following conditions are met:
 
-  * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
 
-  * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
 
-  * Neither the name of the copyright holder nor the names of its
-    contributors may be used to endorse or promote products derived from
-    this software without specific prior written permission.
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY COPYRIGHT HOLDER "AS IS".  COPYRIGHT HOLDER
-EXPRESSLY DISCLAIMS ANY AND ALL WARRANTIES AND CONDITIONS, EITHER
-EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY, TITLE, FITNESS, ADEQUACY OR SUITABILITY
-FOR A PARTICULAR PURPOSE, AND ANY WARRANTIES OF FREEDOM FROM
-INFRINGEMENT OF ANY DOMESTIC OR FOREIGN PATENT, COPYRIGHTS, TRADE
-SECRETS OR OTHER PROPRIETARY RIGHTS OF ANY PARTY.  IN NO EVENT SHALL
-COPYRIGHT HOLDER BE LIABLE TO ANY PARTY FOR ANY DIRECT, INDIRECT,
-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
-USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
-THIS SOFTWARE OR RELATING TO THIS AGREEMENT, EVEN IF ADVISED OF THE
-POSSIBILITY OF SUCH DAMAGE.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/news/rst-migration.rst
+++ b/news/rst-migration.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Migrate documentation to `scikit-package 0.1.0` standards, including a mock import for API rendering.
+
+**Security:**
+
+* <news item>

--- a/src/diffpy/pdffit2/version.py
+++ b/src/diffpy/pdffit2/version.py
@@ -61,3 +61,5 @@ __version__ = version("diffpy.pdffit2")
 __date__ = get_pypi_release_date("diffpy.pdffit2")
 
 # End of file
+
+# Release date: 2025-02-07


### PR DESCRIPTION
I added `autodoc_mock_imports = ["diffpy.pdffit2.pdffit2",]` to `conf.py` due to a circular import error in `src/pdffit2/__init__.py` and `src/pdffit2/pdffit.py`. Without this, the package API does not render. This could be fixed with a "lazy import" in `pdffit.py`, but that seems way more involved and i dont want to break anything. 